### PR TITLE
Fix configuration value loading

### DIFF
--- a/cmd/git-sync/config.go
+++ b/cmd/git-sync/config.go
@@ -53,17 +53,17 @@ func readConfigFromGit(remoteName string) (*config, error) {
 	cfg.gitConfig = gitConfig
 
 	if remoteName == "" {
-		remoteName = gitConfig["sync.remoteName"]
+		remoteName = gitConfig["sync.remotename"]
 	}
 	if remoteName != "" {
 		cfg.remoteName = remoteName
 	}
 
-	if excludePaths := gitConfig["sync.excludePaths"]; excludePaths != "" {
+	if excludePaths := gitConfig["sync.excludepaths"]; excludePaths != "" {
 		cfg.excludePaths = strings.Split(strings.TrimSpace(excludePaths), ":")
 	}
 
-	if rpath := gitConfig["sync.rsyncRemotePath"]; rpath != "" {
+	if rpath := gitConfig["sync.rsyncremotepath"]; rpath != "" {
 		cfg.rsyncRemotePath = rpath
 	}
 

--- a/gitapi/gitapi.go
+++ b/gitapi/gitapi.go
@@ -52,7 +52,7 @@ func (wd *gitWorkDir) GitConfig() (map[string]string, error) {
 		if len(keyValTuple) != 2 {
 			log.Warningf("invalid git config tuple: %d %v", len(keyValTuple), keyValTuple)
 		}
-		gitConfig[keyValTuple[0]] = keyValTuple[1]
+		gitConfig[strings.ToLower(keyValTuple[0])] = keyValTuple[1]
 	}
 	return gitConfig, nil
 }


### PR DESCRIPTION
git-config appears to lowercase keys before returning them, which
meant sync.excludePaths and friends weren't getting found. Look them
up lowercased, instead.

I'm not sure if this is a change in behavior on git's side (it does
this as of 2.20.1, at least), so to make sure, lowercase it outselves
at the ingestion point.