### PR TITLE
Update install instructions

### DIFF
--- a/cmd/git-sync/README.md
+++ b/cmd/git-sync/README.md
@@ -39,6 +39,9 @@ Install tools and configure git:
 go install -v github.com/msolo/git-mg/cmd/git-sync
 go install -v github.com/msolo/git-mg/cmd/git-fsmonitor
 
+# watch the repository
+watchman watch ./
+
 # Configure git - more relevant for large repos, but generally harmless.
 git config core.fsmonitor git-fsmonitor
 git config core.fsmonitorhookversion 1

--- a/cmd/git-sync/README.md
+++ b/cmd/git-sync/README.md
@@ -36,8 +36,8 @@ brew install watchman
 Install tools and configure git:
 ```
 # Get the tools installed
-go get github.com/msolo/git-mg/cmd/git-sync
-go get github.com/msolo/git-mg/cmd/git-fsmonitor
+go install -v github.com/msolo/git-mg/cmd/git-sync
+go install -v github.com/msolo/git-mg/cmd/git-fsmonitor
 
 # Configure git - more relevant for large repos, but generally harmless.
 git config core.fsmonitor git-fsmonitor


### PR DESCRIPTION
go get no longer installs binaries, you have to use `go install`